### PR TITLE
Serviço e cobertura só lista as opções ativas para adicionar ao pacote

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -55,7 +55,7 @@ class PackagesController < ApplicationController
   end
 
   def coverages_and_services
-    @coverages = PackageCoverage.all.order(:name)
-    @services = Service.all.order(:name)
+    @coverages = PackageCoverage.active.order(:name)
+    @services = Service.active.order(:name)
   end
 end

--- a/app/views/packages/_coverage_form.html.erb
+++ b/app/views/packages/_coverage_form.html.erb
@@ -3,23 +3,37 @@
     <h4 class="mb-4">Incluir Cobertura</h4>
     <%= form_with(model: [@package, @coverage_pricing]) do |f| %>
       <div class="row">
-        <div class="mb-3">
-          <%= f.label :package_coverage_id, class: "form-label fw-semibold" %>:
-          <%= f.collection_select :package_coverage_id, @coverages, :id, :name, prompt: true, class: "form-control" %>
+        <div class="mb-3" id="coverage-select">
+          <% if @coverages.empty? %>
+            <%= f.label :package_coverage_id, class: "form-label fw-semibold" %>:
+            <p><%= t '.empty_message' %></p>
+          <% else %>
+            <%= f.label :package_coverage_id, class: "form-label fw-semibold" %>:
+            <%= f.collection_select :package_coverage_id, @coverages, :id, :name, prompt: true, class: "form-control" %>
+          <% end %>
         </div>
         <div class="mb-3 col-auto">
           <div class="row">
-            <div class="col-auto">
-              <%= f.label :percentage_price, class: "form-label fw-semibold" %> (%):
-            </div>
-            <div class="col-auto">
-              <%= f.number_field :percentage_price, step: 0.01, class: "form-control" %>
-            </div>
+            <% if @coverages.empty? %>
+               <div class="col-auto">
+                <%= f.label :percentage_price, class: "form-label fw-semibold" %> (%):
+              </div>
+               <p><%= t '.percentage_empty_message' %></p>
+            <% else %>
+              <div class="col-auto">
+                <%= f.label :percentage_price, class: "form-label fw-semibold" %> (%):
+              </div>
+              <div class="col-auto"  id="coverage-form-field">
+                <%= f.number_field :percentage_price, step: 0.01, class: "form-control" %>
+              </div>
+            <% end %>
           </div>
         </div>
-        <div>
+        <% unless @coverages.empty? %>
+        <div id="coverage-form-button" >
           <%= f.submit 'Adicionar Cobertura', class: "btn btn-dark" %>
         </div>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/packages/_service_form.html.erb
+++ b/app/views/packages/_service_form.html.erb
@@ -3,23 +3,37 @@
     <h4 class="mb-4">Incluir Serviço</h4>
     <%= form_with(model: [@package, @service_pricing]) do |f| %>
       <div class="row">
-        <div class="mb-3">
+        <div class="mb-3" id="service-select">
+        <% if @services.empty? %>
           <%= f.label :service_id, class: "form-label fw-semibold" %>:
+          <p><%= t '.empty_message' %></p>
+        <% else %>
+        <%= f.label :service_id, class: "form-label fw-semibold" %>:
           <%= f.collection_select :service_id, @services, :id, :name, prompt: true, class: "form-control" %>
+        <% end %>
         </div>
         <div class="mb-3 col-auto">
           <div class="row">
+            <% if @services.empty? %>
             <div class="col-auto">
               <%= f.label :percentage_price, class: "form-label fw-semibold" %> (%):
             </div>
+            <p><%= t '.percentage_empty_message' %></p>
+            <% else %>
             <div class="col-auto">
+              <%= f.label :percentage_price, class: "form-label fw-semibold" %> (%):
+            </div>
+            <div class="col-auto" id="service-form-field">
               <%= f.number_field :percentage_price, step: 0.01, class: "form-control" %>
             </div>
+            <% end %>
           </div>
         </div>
-        <div>
+        <% unless @services.empty? %>
+        <div id="service-form-button">
           <%= f.submit 'Adicionar Serviço', class: "btn btn-dark" %>
         </div>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/config/locales/views/package_coverages/show.pt-BR.yml
+++ b/config/locales/views/package_coverages/show.pt-BR.yml
@@ -10,4 +10,3 @@ pt-BR:
       status: 'Status'
       deactivate: 'Desativar'
       activate: 'Ativar'
-    

--- a/config/locales/views/packages/_coverage_form.pt-BR copy.yml
+++ b/config/locales/views/packages/_coverage_form.pt-BR copy.yml
@@ -1,0 +1,5 @@
+pt-BR:
+  packages:
+    coverage_form:
+       empty_message: 'Não há coberturas ativos'
+       percentage_empty_message: 'É preciso adicionar cobertura'

--- a/config/locales/views/packages/_service_form.pt-BR.yml
+++ b/config/locales/views/packages/_service_form.pt-BR.yml
@@ -1,0 +1,5 @@
+pt-BR:
+  packages:
+    service_form:
+       empty_message: 'Não há serviços ativos'
+       percentage_empty_message: 'É preciso adicionar serviço'

--- a/spec/system/package/user_adds_coverage_to_package_spec.rb
+++ b/spec/system/package/user_adds_coverage_to_package_spec.rb
@@ -142,8 +142,6 @@ describe 'Usuário visita pagina para criar pacote' do
 
     within '#coverage-select' do
       expect(page).not_to have_content 'Quebra de tela'
-    end
-    within '#coverage-select' do
       expect(page).to have_content 'Molhar'
     end
   end

--- a/spec/system/package/user_adds_service_to_package_spec.rb
+++ b/spec/system/package/user_adds_service_to_package_spec.rb
@@ -151,8 +151,6 @@ describe 'Usuário visita pagina para criar pacote' do
 
     within '#service-select' do
       expect(page).to have_content 'Desconto no Clube'
-    end
-    within '#service-select' do
       expect(page).not_to have_content 'Assinatura TV'
     end
   end


### PR DESCRIPTION
closes #159 

Segue exemplo para quando nenhum serviço estiver ativo:
![não ativo](https://user-images.githubusercontent.com/101022596/204031407-c2ebcc12-651e-4f39-890f-b76b13489198.PNG)
